### PR TITLE
updating DNS TTL to 30s

### DIFF
--- a/main.go
+++ b/main.go
@@ -181,7 +181,7 @@ func getCurrentCNAME(c *conf, domain string) (string, error) {
 }
 
 func createDNS(c *conf, elbCNAME string, domain string) error {
-	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"rdata\": \"%s\",\"ttl\": \"600\"}", domain, elbCNAME)
+	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"rdata\": \"%s\",\"ttl\": \"30\"}", domain, elbCNAME)
 	req, err := http.NewRequest(http.MethodPost, c.konsDNSEndPoint, strings.NewReader(body))
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ func createDNS(c *conf, elbCNAME string, domain string) error {
 }
 
 func updateDNS(c *conf, oldCname string, newCname, domain string) error {
-	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"oldRdata\": \"%s\",\"newRdata\": \"%s\",\"ttl\": \"600\"}", domain, oldCname, newCname)
+	body := fmt.Sprintf("{\"zone\": \"ft.com\", \"name\": \"%s\",\"oldRdata\": \"%s\",\"newRdata\": \"%s\",\"ttl\": \"30\"}", domain, oldCname, newCname)
 	req, err := http.NewRequest(http.MethodPut, c.konsDNSEndPoint, strings.NewReader(body))
 	if err != nil {
 		return err


### PR DESCRIPTION
This is currently set to 10 mins - which causes a delay when reprovisioning clusters with the same name, as the lowest level CNAME pointing to the ELB (and the tunnel addresses etc) take time to update to the new cluster.  
We don't do cluster reprovisioning with the same name very often, but when we do (say, when attempting to recover during an incident), we want to get it done ASAP.  

Our other DNS records in a cluster (top level CNAME, traffic managed CNAME) are set to 30s already, so setting it here will make it consistent with the other records. 60s would probably be fine as well, if people wanted it to be higher.  

Have checked with Nikita Lohia in Central Services, she's happy with the proposed changes - we're not going to be incurring any additional costs from the extra Dyn lookups, and we're not on the list of top 10 hostnames with highest queries per second.
