### PR TITLE
Remove unused AWS props

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ How to Build & Run the binary
 
 2. Run:
 
-        export AWS_SECRET_ACCESS_KEY="***" \
-            && export AWS_ACCESS_KEY_ID="***" \
-            && export AWS_REGION="eu-west-1" \
-            && export ELB_NAME="coreos-up-176d2040" \
+        export ELB_NAME="coreos-up-176d2040" \
             && export DOMAINS="xp-up,xp-read-up" \
             && export KONSTRUCTOR_BASE_URL="https://dns-api.in.ft.com/v2" \
             && export KONSTRUCTOR_API_KEY="***" \

--- a/main.go
+++ b/main.go
@@ -46,21 +46,6 @@ func main() {
 		Desc:   "konstructor api key",
 		EnvVar: "KONSTRUCTOR_API_KEY",
 	})
-	awsRegion := app.String(cli.StringOpt{
-		Name:   "aws-region",
-		Desc:   "aws region",
-		EnvVar: "AWS_REGION",
-	})
-	awsAccessKeyID := app.String(cli.StringOpt{
-		Name:   "aws_access_key_id",
-		Desc:   "aws access key id",
-		EnvVar: "AWS_ACCESS_KEY_ID",
-	})
-	awsSecretAccessKey := app.String(cli.StringOpt{
-		Name:   "aws_secret_access_key",
-		Desc:   "aws secret access key",
-		EnvVar: "AWS_SECRET_ACCESS_KEY",
-	})
 
 	kubeLbService := app.String(cli.StringOpt{
 		Name:   "k8s-lb-service",
@@ -78,9 +63,6 @@ func main() {
 		conf := &conf{
 			konsAPIKey:             *konstructorAPIKey,
 			konsDNSEndPoint:        *konstructorBaseURL,
-			awsAccessKey:           *awsAccessKeyID,
-			awsSecretKey:           *awsSecretAccessKey,
-			awsRegion:              *awsRegion,
 			kubeLbService:          *kubeLbService,
 			kubeLbServiceNamespace: *kubeLBServiceNamespace,
 		}

--- a/main.go
+++ b/main.go
@@ -120,9 +120,6 @@ type conf struct {
 	konsAPIKey             string
 	konsDNSEndPoint        string
 	elbName                string
-	awsAccessKey           string
-	awsSecretKey           string
-	awsRegion              string
 	kubeLbService          string
 	kubeLbServiceNamespace string
 }


### PR DESCRIPTION
- the elb registrator needs to get the ELB which needs the CNAME - in the beginning this was done with AWS, but after we migrated to K8S, we're getting the ELB from the Kubernetes API, we just forgot to remove the AWS props